### PR TITLE
Fake, in-memory implementation of HTable: initial import.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,2 @@
+This product includes software developed by WibiData, Inc.
+(http://www.wibidata.com)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-fake-htable
-===========
+FakeHTable ${project.version}
+=============================
 
-A faked htable implementation for testing of HBase applications
+FakeHTable provides a fake in-memory implementation of HTableInterface
+and HBaseAdmin, for unit-testing purposes.
+
+Compilation
+-----------
+
+FakeHTable requires [Apache Maven 3](http://maven.apache.org/download.html) to build. It
+may be built with the command
+
+    mvn clean package
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,106 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+    (c) Copyright 2012 WibiData, Inc.
+
+    See the NOTICE file distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.kiji.testing</groupId>
+  <artifactId>fake-hbase</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.kiji.pom</groupId>
+    <artifactId>root-pom</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <name>fake-htable</name>
+  <description>
+    Fake HBase table implementation, for testing purposes.
+  </description>
+  <url>http://www.kiji.org</url>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>process-resources</phase>
+            <goals> <goal>add-source</goal> <goal>compile</goal> </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <phase>process-test-resources</phase>
+            <goals> <goal>testCompile</goal> </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includes><include>**/*.scala</include><include>**/*.java</include></includes>
+          <displayCmd>true</displayCmd>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <!-- Scala runtime -->
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- HBase -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Hadoop -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Bring EasyMock ability to proxy concrete classes -->
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/main/findbugs/excludeFilter.xml
+++ b/src/main/findbugs/excludeFilter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<!-- (c) Copyright 2012 WibiData, Inc. -->
+<FindBugsFilter>
+</FindBugsFilter>

--- a/src/main/findbugs/includeFilter.xml
+++ b/src/main/findbugs/includeFilter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<!-- (c) Copyright 2012 WibiData, Inc. -->
+<FindBugsFilter>
+</FindBugsFilter>

--- a/src/main/java/org/kiji/testing/fakehtable/HTableInterfaceFactory.java
+++ b/src/main/java/org/kiji/testing/fakehtable/HTableInterfaceFactory.java
@@ -1,0 +1,38 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTableInterface;
+
+/** Factory for HTableInterface. */
+public interface HTableInterfaceFactory {
+  /**
+  * Creates a new HTableInterface instance.
+  *
+  * @param conf Configuration.
+  * @param tableName Table name, as a UTF-8 string.
+  * @return a new HTableInterface for the specified table.
+  * @throws IOException on I/O error.
+  */
+  HTableInterface create(Configuration conf, String tableName) throws IOException;
+}

--- a/src/main/java/org/kiji/testing/fakehtable/PythonProxy.java
+++ b/src/main/java/org/kiji/testing/fakehtable/PythonProxy.java
@@ -1,0 +1,67 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable;
+
+import java.lang.reflect.InvocationTargetException;
+
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+
+/**
+ * Forwards method calls to an arbitrary handler.
+ *
+ * This is part of the ugly mess that allows to provide a fake HBaseAdmin implementation that
+ * appears as an instance of the concrete class HBaseAdmin. Because interfaces are for bunnies...
+ *
+ * This class apparently needs to be a Java class, and cannot be Scala, otherwise the forwarded
+ * method invocation fails with an illegal parameter error.
+ *
+ * @param <T> class of the handler.
+ */
+public class PythonProxy<T> implements MethodInterceptor {
+  /** Target handler for intercepted/proxied method calls. */
+  private final T mTarget;
+
+  /**
+   * Initialises the proxy.
+   *
+   * @param target Target handler for intercepted/proxied method calls.
+   */
+  public PythonProxy(T target) {
+    mTarget = target;
+  }
+
+  @Override
+  public Object intercept(
+      Object self,
+      java.lang.reflect.Method method,
+      Object[] args,
+      MethodProxy proxy)
+      throws Throwable {
+    // Forwards the method call to the underlying handler, through reflection:
+    try {
+      return mTarget.getClass()
+          .getMethod(method.getName(), method.getParameterTypes())
+          .invoke(mTarget, args);
+    } catch (InvocationTargetException ite) {
+      throw ite.getCause();
+    }
+  }
+}

--- a/src/main/java/org/kiji/testing/fakehtable/package-info.java
+++ b/src/main/java/org/kiji/testing/fakehtable/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Java-side of the fake HTable implementation. */
+package org.kiji.testing.fakehtable;

--- a/src/main/scala/org/kiji/testing/fakehtable/FakeHBase.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/FakeHBase.scala
@@ -1,0 +1,219 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import java.util.{List => JList}
+import java.util.{TreeMap => JTreeMap}
+
+import scala.collection.JavaConverters._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client.HBaseAdmin
+import org.apache.hadoop.hbase.client.HTableInterface
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.HColumnDescriptor
+import org.apache.hadoop.hbase.HRegionInfo
+import org.apache.hadoop.hbase.HTableDescriptor
+import org.apache.hadoop.hbase.TableNotFoundException
+import org.apache.hadoop.hbase.TableNotDisabledException
+import org.apache.hadoop.hbase.TableExistsException
+import net.sf.cglib.proxy.MethodInterceptor
+import net.sf.cglib.proxy.MethodProxy
+
+// -------------------------------------------------------------------------------------------------
+
+
+/** Fake HBase instance, as a collection of fake HTable instances. */
+class FakeHBase {
+  type Bytes = Array[Byte]
+
+  /** Controls whether to automatically create unknown tables or throw a TableNotFoundException. */
+  // TODO Make this configurable
+  private val CreateUnknownTable = true
+
+  /** Map of the tables. */
+  private[fakehtable] val tableMap = new JTreeMap[Bytes, FakeHTable](Bytes.BYTES_COMPARATOR)
+
+  // -----------------------------------------------------------------------------------------------
+
+  /** Factory for HTableInterface instances. */
+  object InterfaceFactory
+      extends org.kiji.testing.fakehtable.HTableInterfaceFactory
+      with org.apache.hadoop.hbase.client.HTableInterfaceFactory {
+
+    override def create(conf: Configuration, tableName: String): HTableInterface = {
+      val tableNameBytes = Bytes.toBytes(tableName)
+      synchronized {
+        var table = tableMap.get(tableNameBytes)
+        if (table == null) {
+          if (!CreateUnknownTable) {
+            throw new TableNotFoundException(tableName)
+          }
+          val desc = new HTableDescriptor(tableName)
+          table = new FakeHTable(name = tableName, conf = conf, desc = desc)
+          tableMap.put(tableNameBytes, table)
+        }
+        return table
+      }
+    }
+
+    override def createHTableInterface(
+        conf: Configuration,
+        tableName: Bytes
+    ): HTableInterface = {
+      return create(tableName = Bytes.toString(tableName), conf = conf)
+    }
+
+    override def releaseHTableInterface(table: HTableInterface): Unit = {
+      // Do nothing
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+
+  object Admin extends HBaseAdminCore with HBaseAdminConversionHelpers {
+    def addColumn(tableName: Bytes, column: HColumnDescriptor): Unit = {
+        // TODO(taton) Implement metadata
+      // For now, do nothing
+    }
+
+    def createTable(desc: HTableDescriptor, split: Array[Bytes]): Unit = {
+      // TODO(taton) Implement split
+      synchronized {
+        if (tableMap.containsKey(desc.getName)) {
+          throw new TableExistsException(desc.getNameAsString)
+        }
+        val table = new FakeHTable(
+            name = desc.getNameAsString,
+            conf = null,
+            desc = desc
+        )
+        tableMap.put(desc.getName, table)
+      }
+    }
+
+    def createTable(
+        desc: HTableDescriptor,
+        startKey: Bytes,
+        endKey: Bytes,
+        numRegions: Int
+    ): Unit = {
+      // TODO(taton) Implement split
+      createTable(desc = desc, split = null)
+    }
+
+    def deleteColumn(tableName: Bytes, columnName: Bytes): Unit = {
+      // TODO(taton) Implement metadata
+      // For now, do nothing
+    }
+
+    def deleteTable(tableName: Bytes): Unit = {
+      synchronized {
+        val table = tableMap.get(tableName)
+        if (table == null) {
+          throw new TableNotFoundException(Bytes.toStringBinary(tableName))
+        }
+        if (table.enabled) {
+          throw new TableNotDisabledException(tableName)
+        }
+        tableMap.remove(tableName)
+      }
+    }
+
+    def disableTable(tableName: Bytes): Unit = {
+      synchronized {
+        val table = tableMap.get(tableName)
+        if (table == null) {
+          throw new TableNotFoundException(Bytes.toStringBinary(tableName))
+        }
+        table.enabled = false
+      }
+    }
+
+    def enableTable(tableName: Bytes): Unit = {
+      synchronized {
+        val table = tableMap.get(tableName)
+        if (table == null) {
+          throw new TableNotFoundException(Bytes.toStringBinary(tableName))
+        }
+        table.enabled = true
+      }
+    }
+
+    def flush(tableName: Bytes): Unit = {
+      // Nothing to do
+    }
+
+    def getTableRegions(tableName: Bytes): JList[HRegionInfo] = {
+      synchronized {
+        val list = new java.util.ArrayList[HRegionInfo]()
+        val region = new HRegionInfo(tableName)
+        list.add(region)
+        return list
+      }
+    }
+
+    def isTableAvailable(tableName: Bytes): Boolean = {
+      return isTableEnabled(tableName)
+    }
+
+    def isTableEnabled(tableName: Bytes): Boolean = {
+      synchronized {
+        val table = tableMap.get(tableName)
+        if (table == null) {
+          throw new TableNotFoundException(Bytes.toStringBinary(tableName))
+        }
+        return table.enabled
+      }
+    }
+
+    def listTables(): Array[HTableDescriptor] = {
+      synchronized {
+        return tableMap.values.iterator.asScala
+            .map { table => table.desc }
+            .toArray
+      }
+    }
+
+    def modifyColumn(tableName: Bytes, column: HColumnDescriptor): Unit = {
+      // TODO(taton) Implement metadata
+    }
+
+    def modifyTable(tableName: String, desc: HTableDescriptor): Unit = {
+      // TODO(taton) Implement metadata
+    }
+
+    def tableExists(tableName: Bytes): Boolean = {
+      synchronized {
+        return tableMap.containsKey(tableName)
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+
+  /** Factory for HBaseAdmin instances. */
+  object AdminFactory {
+    /** Creates a new HBaseAdmin for this HBase instance. */
+    def create(): HBaseAdmin = {
+      return Proxy.create(classOf[HBaseAdmin], new PythonProxy(Admin))
+    }
+  }
+
+}

--- a/src/main/scala/org/kiji/testing/fakehtable/FakeHTable.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/FakeHTable.scala
@@ -1,0 +1,621 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import java.util.{Iterator => JIterator}
+import java.util.{Map => JMap}
+import java.util.NavigableSet
+import java.util.Arrays
+import java.util.{List => JList}
+import java.util.NavigableMap
+import java.util.{TreeMap => JTreeMap}
+import java.util.{TreeSet => JTreeSet}
+import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.collection.JavaConverters.asScalaSetConverter
+import scala.collection.JavaConverters.mapAsScalaMapConverter
+import scala.collection.mutable.Buffer
+import scala.util.control.Breaks.break
+import scala.util.control.Breaks.breakable
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client.coprocessor.Batch
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Get
+import org.apache.hadoop.hbase.client.HTableInterface
+import org.apache.hadoop.hbase.client.Increment
+import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.Result
+import org.apache.hadoop.hbase.client.ResultScanner
+import org.apache.hadoop.hbase.client.Row
+import org.apache.hadoop.hbase.client.RowLock
+import org.apache.hadoop.hbase.client.Scan
+import org.apache.hadoop.hbase.io.TimeRange
+import org.apache.hadoop.hbase.ipc.CoprocessorProtocol
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.HConstants
+import org.apache.hadoop.hbase.HTableDescriptor
+import org.apache.hadoop.hbase.KeyValue
+import org.slf4j.LoggerFactory
+import org.kiji.testing.fakehtable.JNavigableMapWithAsScalaIterator.javaNavigableMapAsScalaIterator;
+import java.io.PrintStream
+
+/**
+ * Fake in-memory HTable.
+ *
+ * @param name Table name.
+ * @param conf Table configuration.
+ * @param desc Table descriptor.
+ * @param autoFlush auto-flush flag.
+ * @param enabled Whether the table is enabled.
+ */
+class FakeHTable(
+    val name: String,
+    val conf: Configuration,
+    val desc: HTableDescriptor,
+    private var autoFlush: Boolean = false,
+    private var writeBufferSize: Long = 1,
+    var enabled: Boolean = true
+) extends HTableInterface {
+  private val Log = LoggerFactory.getLogger(getClass)
+
+  /** Whether the table has been closed. */
+  private var closed: Boolean = false
+
+  /** Byte array shortcut. */
+  type Bytes = Array[Byte]
+
+  /** Time series in a column, ordered by decreasing time stamps. */
+  type ColumnSeries = NavigableMap[Long, Bytes]
+
+  /** Map column qualifiers to cell series. */
+  type FamilyQualifiers = NavigableMap[Bytes, ColumnSeries]
+
+  /** Map of column family names to qualifier maps. */
+  type RowFamilies = NavigableMap[Bytes, FamilyQualifiers]
+
+  /** Map of row keys. */
+  type Table = NavigableMap[Bytes, RowFamilies]
+
+  /** Map: row key -> family -> qualifier -> timestamp -> cell data. */
+  private val rows: Table = new JTreeMap[Bytes, RowFamilies](Bytes.BYTES_COMPARATOR)
+
+  override def getTableName(): Array[Byte] = {
+    return name.getBytes
+  }
+
+  override def getConfiguration(): Configuration = {
+    return conf
+  }
+
+  override def getTableDescriptor(): HTableDescriptor = {
+    return desc
+  }
+
+  override def exists(get: Get): Boolean = {
+    return !this.get(get).isEmpty()
+  }
+
+  override def batch(actions: JList[Row], results: Array[Object]): Unit = {
+    require(results.size == actions.size)
+    val array = batch(actions)
+    System.arraycopy(array, 0, results, 0, results.length)
+  }
+
+  override def batch(actions: JList[Row]): Array[Object] = {
+    val results = Buffer[Object]()
+    actions.asScala.foreach { action =>
+      action match {
+        case put: Put => {
+          this.put(put)
+          results += new Object()
+        }
+        case get: Get => {
+          results += this.get(get)
+        }
+        case delete: Delete => {
+          this.delete(delete)
+          results += new Object()
+        }
+        case increment: Increment => {
+          results += this.increment(increment)
+        }
+      }
+    }
+    return results.toArray
+  }
+
+  override def get(get: Get): Result = {
+    val rowKey = get.getRow
+    val row = rows.get(rowKey)
+    if (row == null) {
+      return new Result()  // empty result
+    } else {
+      return makeResult(
+          rowKey = rowKey,
+          row = row,
+          familyMap = get.getFamilyMap,
+          timeRange = get.getTimeRange,
+          maxVersions = get.getMaxVersions
+      )
+    }
+  }
+
+  override def get(gets: JList[Get]): Array[Result] = {
+    return gets.asScala.map(this.get(_)).toArray
+  }
+
+  @deprecated(message = "Deprecated method will not be implemented", since = "HBase 0.92")
+  override def getRowOrBefore(row: Bytes, family: Bytes): Result = {
+    sys.error("Deprecated method will not be implemented")
+  }
+
+  override def getScanner(scan: Scan): ResultScanner = {
+    return new FakeResultScanner(scan)
+  }
+
+  override def getScanner(family: Bytes): ResultScanner = {
+    return getScanner(new Scan().addFamily(family))
+  }
+
+  override def getScanner(family: Bytes, qualifier: Bytes): ResultScanner = {
+    return getScanner(new Scan().addColumn(family, qualifier))
+  }
+
+  override def put(put: Put): Unit = {
+    synchronized {
+      val nowMS = System.currentTimeMillis
+
+      val rowKey = put.getRow
+      val rowFamilyMap = rows.asScala
+          .getOrElseUpdate(rowKey, new JTreeMap[Bytes, FamilyQualifiers](Bytes.BYTES_COMPARATOR))
+      for ((family, kvs) <- put.getFamilyMap.asScala) {
+        val rowQualifierMap = rowFamilyMap.asScala
+            .getOrElseUpdate(family, new JTreeMap[Bytes, ColumnSeries](Bytes.BYTES_COMPARATOR))
+
+        for (kv <- kvs.asScala) {
+          require(family.toSeq == kv.getFamily.toSeq)
+
+          val column = rowQualifierMap.asScala
+              .getOrElseUpdate(kv.getQualifier, new JTreeMap[Long, Bytes](TimestampComparator))
+
+          val timestamp = {
+            if (kv.getTimestamp == HConstants.LATEST_TIMESTAMP) {
+              nowMS
+            } else {
+              kv.getTimestamp
+            }
+          }
+
+          column.put(timestamp, kv.getValue)
+        }
+      }
+    }
+  }
+
+  override def put(put: JList[Put]): Unit = {
+    put.asScala.foreach(this.put(_))
+  }
+
+  /**
+   * Checks the value of a cell.
+   *
+   * @param row Row key.
+   * @param family Family.
+   * @param qualifier Qualifier.
+   * @param value Value to compare against.
+   *     Null means check that the specified cell does not exist.
+   * @return whether the HBase cell check is successful, ie. whether the specified cell exists
+   *     and contains the given value, or whether the cell does not exist.
+   */
+  private def checkCell(row: Bytes, family: Bytes, qualifier: Bytes, value: Bytes): Boolean = {
+    if (value == null) {
+      val fmap = rows.get(row)
+      if (fmap == null) return true
+      val qmap = fmap.get(family)
+      if (qmap == null) return true
+      val tmap = qmap.get(qualifier)
+      return (tmap == null) || tmap.isEmpty
+    } else {
+      val fmap = rows.get(row)
+      if (fmap == null) return false
+      val qmap = fmap.get(family)
+      if (qmap == null) return false
+      val tmap = qmap.get(qualifier)
+      if ((tmap == null) || tmap.isEmpty) return false
+      return Arrays.equals(tmap.firstEntry.getValue, value)
+    }
+  }
+
+  override def checkAndPut(
+      row: Bytes,
+      family: Bytes,
+      qualifier: Bytes,
+      value: Bytes,
+      put: Put
+  ): Boolean = {
+    synchronized {
+      if (checkCell(row = row, family = family, qualifier = qualifier, value = value)) {
+        this.put(put)
+        return true
+      } else {
+        return false
+      }
+    }
+  }
+
+  override def delete(delete: Delete): Unit = {
+    val rowKey = delete.getRow
+    val row = rows.get(rowKey)
+    if (row == null) { return }
+
+    if (delete.getFamilyMap.isEmpty) {
+      for ((family, qualifiers) <- row.asScala) {
+        for ((qualifier, series) <- qualifiers.asScala) {
+          series.subMap(delete.getTimeStamp, true, 0, true).clear()
+        }
+      }
+      return
+    }
+
+    for ((requestedFamily, kvs) <- delete.getFamilyMap.asScala) {
+      val rowQualifierMap = row.get(requestedFamily)
+      if (rowQualifierMap != null) {
+        for (kv <- kvs.asScala) {
+          require(kv.isDelete)
+          if (kv.isDeleteFamily) {
+            // Removes versions of an entire family prior to the specified timestamp:
+            for ((qualifier, series) <- rowQualifierMap.asScala) {
+              series.subMap(kv.getTimestamp, true, 0, true).clear()
+            }
+          } else if (kv.isDeleteColumnOrFamily) {
+            // Removes versions of a column prior to the specified timestamp:
+            val series = rowQualifierMap.get(kv.getQualifier)
+            if (series != null) {
+              series.subMap(kv.getTimestamp, true, 0, true).clear()
+            }
+          } else {
+            // Removes exactly one cell:
+            val series = rowQualifierMap.get(kv.getQualifier)
+            if (series != null) {
+              series.remove(kv.getTimestamp)
+            }
+          }
+        }
+        sys.error("Not implemented")
+      }
+    }
+  }
+
+  override def delete(deletes: JList[Delete]): Unit = {
+    deletes.asScala.foreach(this.delete(_))
+  }
+
+  override def checkAndDelete(
+      row: Bytes,
+      family: Bytes,
+      qualifier: Bytes,
+      value: Bytes,
+      delete: Delete
+  ): Boolean = {
+    synchronized {
+      if (checkCell(row = row, family = family, qualifier = qualifier, value = value)) {
+        this.delete(delete)
+        return true
+      } else {
+        return false
+      }
+    }
+  }
+
+  override def increment(increment: Increment): Result = {
+    synchronized {
+      val nowMS = System.currentTimeMillis
+
+      val rowKey = increment.getRow
+      val row = rows.asScala
+          .getOrElseUpdate(rowKey, new JTreeMap[Bytes, FamilyQualifiers](Bytes.BYTES_COMPARATOR))
+      val familyMap = new JTreeMap[Bytes, NavigableSet[Bytes]](Bytes.BYTES_COMPARATOR)
+
+      for ((family, qualifierMap) <- increment.getFamilyMap.asScala) {
+        val qualifierSet = familyMap.asScala
+            .getOrElseUpdate(family, new JTreeSet[Bytes](Bytes.BYTES_COMPARATOR))
+        val rowQualifierMap = row.asScala
+            .getOrElseUpdate(family, new JTreeMap[Bytes, ColumnSeries](Bytes.BYTES_COMPARATOR))
+
+        for ((qualifier, amount) <- qualifierMap.asScala) {
+          qualifierSet.add(qualifier)
+          val rowTimeSeries = rowQualifierMap.asScala
+              .getOrElseUpdate(qualifier, new JTreeMap[Long, Bytes](TimestampComparator))
+          val currentCounter = {
+            if (rowTimeSeries.isEmpty) {
+              0
+            } else {
+              Bytes.toLong(rowTimeSeries.firstEntry.getValue)
+            }
+          }
+          val newCounter = currentCounter + amount
+          Log.debug("Updating counter from %d to %d".format(currentCounter, newCounter))
+          rowTimeSeries.put(nowMS, Bytes.toBytes(newCounter))
+        }
+      }
+
+      return makeResult(
+          rowKey = increment.getRow,
+          row = row,
+          familyMap = familyMap,
+          timeRange = increment.getTimeRange,
+          maxVersions = 1
+      )
+    }
+  }
+
+  override def incrementColumnValue(
+      row: Bytes,
+      family: Bytes,
+      qualifier: Bytes,
+      amount: Long
+  ): Long = {
+    return this.incrementColumnValue(row, family, qualifier, amount, writeToWAL = true)
+  }
+
+  override def incrementColumnValue(
+      row: Bytes,
+      family: Bytes,
+      qualifier: Bytes,
+      amount: Long,
+      writeToWAL: Boolean
+  ): Long = {
+    val inc = new Increment(row)
+        .addColumn(family, qualifier, amount)
+    val result = this.increment(inc)
+    require(!result.isEmpty)
+    return Bytes.toLong(result.getValue(family, qualifier))
+  }
+
+  override def setAutoFlush(autoFlush: Boolean, clearBufferOnFail: Boolean): Unit = {
+    this.autoFlush = autoFlush
+    // Ignore clearBufferOnFail
+  }
+
+  override def setAutoFlush(autoFlush: Boolean): Unit = {
+    this.autoFlush = autoFlush
+  }
+
+  override def isAutoFlush(): Boolean = {
+    return autoFlush
+  }
+
+  override def flushCommits(): Unit = {
+    // Do nothing
+  }
+
+  override def setWriteBufferSize(writeBufferSize: Long): Unit = {
+    this.writeBufferSize = writeBufferSize
+  }
+
+  override def getWriteBufferSize(): Long = {
+    return writeBufferSize
+  }
+
+  override def close(): Unit = {
+    this.closed = true
+  }
+
+  override def lockRow(row: Bytes): RowLock = {
+    sys.error("Not implemented")
+  }
+
+  override def unlockRow(lock: RowLock): Unit = {
+    sys.error("Not implemented")
+  }
+
+  override def coprocessorProxy[T <: CoprocessorProtocol](
+      protocol: Class[T],
+      row: Bytes
+  ): T = {
+    sys.error("Coprocessor not implemented")
+  }
+
+  override def coprocessorExec[T <: CoprocessorProtocol, R](
+      protocol: Class[T],
+      startKey: Bytes,
+      endKey: Bytes,
+      callable: Batch.Call[T, R]
+  ): JMap[Bytes, R] = {
+    sys.error("Coprocessor not implemented")
+  }
+
+  override def coprocessorExec[T <: CoprocessorProtocol, R](
+      protocol: Class[T],
+      startKey: Bytes,
+      endKey: Bytes,
+      callable: Batch.Call[T, R],
+      callback: Batch.Callback[R]
+  ): Unit = {
+    sys.error("Coprocessor not implemented")
+  }
+
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Builds an HTable request Result instance.
+   *
+   * @param rowKey the row key.
+   * @param row the actual row data.
+   * @param familyMap the requested columns.
+   * @param timeRange the timestamp range.
+   * @param maxVersions maximum number of versions to return.
+   * @return a new Result instance with the specified cells (KeyValue entries).
+   */
+  private def makeResult(
+      rowKey: Bytes,
+      row: RowFamilies,
+      familyMap: JMap[Bytes, NavigableSet[Bytes]],
+      timeRange: TimeRange,
+      maxVersions: Int
+  ): Result = {
+    val kvs = Buffer[KeyValue]()
+    val requestedFamilies = if (!familyMap.isEmpty) familyMap.keySet else row.keySet
+    for (requestedFamily <- requestedFamilies.asScala) {
+      /** Map: qualifier -> time stamp -> cell value */
+      val rowQualifierMap = row.get(requestedFamily)
+      if (rowQualifierMap != null) {
+        val requestedQualifiers = {
+          val qset = familyMap.get(requestedFamily)
+          if ((qset != null) && !qset.isEmpty) qset else rowQualifierMap.keySet
+        }
+        for (requestedQualifier <- requestedQualifiers.asScala) {
+          /** Map: time stamp -> cell value */
+          val rowColumnSeries = rowQualifierMap.get(requestedQualifier)
+          if (rowColumnSeries != null) {
+            /** Map: time stamp -> cell value */
+            val versionMap = rowColumnSeries.subMap(timeRange.getMax, false, timeRange.getMin, true)
+            breakable {
+              for ((timestamp, value) <- versionMap.asScalaIterator) {
+                val kv = new KeyValue(rowKey, requestedFamily, requestedQualifier, timestamp, value)
+                kvs += kv
+                if (kvs.size >= maxVersions) {
+                  break
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return new Result(kvs.toArray)
+  }
+
+  // -----------------------------------------------------------------------------------------------
+
+  def toHex(bytes: Bytes): String = {
+    return bytes.iterator
+        .map { byte => "%02x".format(byte) }
+        .mkString(":")
+  }
+
+  def toString(bytes: Bytes): String = {
+    return Bytes.toStringBinary(bytes)
+  }
+
+  /**
+   * Dumps the content of the fake HTable.
+   *
+   * @param out Optional print stream to write to.
+   */
+  def dump(out: PrintStream = Console.out): Unit = {
+    for ((rowKey, familyMap) <- rows.asScalaIterator) {
+      for ((family, qualifierMap) <- familyMap.asScalaIterator) {
+        for ((qualifier, timeSeries) <- qualifierMap.asScalaIterator) {
+          for ((timestamp, value) <- timeSeries.asScalaIterator) {
+            out.println("row=%s family=%s qualifier=%s timestamp=%d value=%s".format(
+                toString(rowKey),
+                toString(family),
+                toString(qualifier),
+                timestamp,
+                toHex(value)))
+          }
+        }
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * ResultScanner for a fake in-memory HTable.
+   *
+   * @param scan Scan options.
+   */
+  private class FakeResultScanner(
+      val scan: Scan
+  ) extends ResultScanner with JIterator[Result] {
+
+    /** Key of the row to return on the next call to next(). Null means no more row. */
+    private var key: Bytes = {
+      if (rows.isEmpty) {
+        null
+      } else if (scan.getStartRow.isEmpty) {
+        rows.firstKey
+      } else {
+        rows.floorKey(scan.getStartRow)
+      }
+    }
+    if (!scan.getStopRow.isEmpty
+       && (Bytes.BYTES_COMPARATOR.compare(key, scan.getStopRow) >= 0)) {
+      key = null
+    }
+
+    override def hasNext(): Boolean = {
+      return (key != null)
+    }
+
+    override def next(): Result = {
+      if (key == null) { return null }
+
+      /** Map: family -> qualifier -> time stamp -> cell value */
+      val rowKey = key
+      val row = rows.get(key)
+      require(row != null)
+
+      // Advance to next key
+      key = rows.higherKey(key)
+      if ((key != null)
+          && !scan.getStopRow.isEmpty
+          && (Bytes.BYTES_COMPARATOR.compare(key, scan.getStopRow) >= 0)) {
+        key = null
+      }
+
+      return makeResult(
+          rowKey = rowKey,
+          row = row,
+          familyMap = scan.getFamilyMap,
+          timeRange = scan.getTimeRange,
+          maxVersions = scan.getMaxVersions
+      )
+    }
+
+    override def next(nrows: Int): Array[Result] = {
+      val results = Buffer[Result]()
+      breakable {
+        for (nrow <- 0 until nrows) {
+          next() match {
+            case null => break
+            case row => results += row
+          }
+        }
+      }
+      return results.toArray
+    }
+
+    override def close(): Unit = {
+      // Nothing to close
+    }
+
+    override def iterator(): JIterator[Result] = {
+      return this
+    }
+
+    override def remove(): Unit = {
+      throw new UnsupportedOperationException
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+}

--- a/src/main/scala/org/kiji/testing/fakehtable/HBaseAdminInterface.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/HBaseAdminInterface.scala
@@ -1,0 +1,288 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import java.io.Closeable
+import java.util.regex.Pattern
+import java.util.Arrays
+import java.util.{List => JList}
+
+import scala.collection.mutable
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+import org.apache.hadoop.hbase.util.Bytes.toBytes
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.HColumnDescriptor
+import org.apache.hadoop.hbase.HRegionInfo
+import org.apache.hadoop.hbase.HTableDescriptor
+import org.apache.hadoop.hbase.TableNotFoundException
+
+
+/** Core HBaseAdmin interface. */
+trait HBaseAdminCore
+    extends Closeable {
+
+  type Bytes = Array[Byte]
+
+  def addColumn(tableName: Bytes, column: HColumnDescriptor): Unit
+
+  def createTable(desc: HTableDescriptor, split: Array[Bytes]): Unit
+  def createTable(
+      desc: HTableDescriptor,
+      startKey: Bytes,
+      endKey: Bytes,
+      numRegions: Int
+  ): Unit
+
+  def deleteColumn(tableName: Bytes, columnName: Bytes): Unit
+
+  def deleteTable(tableName: Bytes): Unit
+
+  def disableTable(tableName: Bytes): Unit
+
+  def enableTable(tableName: Bytes): Unit
+
+  def flush(tableName: Bytes): Unit
+
+  def getTableRegions(tableName: Bytes): JList[HRegionInfo]
+
+  def isTableAvailable(tableName: Bytes): Boolean
+
+  def isTableEnabled(tableName: Bytes): Boolean
+
+  def listTables(): Array[HTableDescriptor]
+
+  def modifyColumn(tableName: Bytes, column: HColumnDescriptor): Unit
+
+  def modifyTable(tableName: String, desc: HTableDescriptor): Unit
+
+  def tableExists(tableName: Bytes): Boolean
+}
+
+
+/**
+ * Pure interface for compatibility with the concrete Java class HBaseAdmin.
+ *
+ * Extends HBaseAdminCore with helpers to convert between Bytes and String.
+ */
+trait HBaseAdminInterface
+    extends HBaseAdminCore {
+
+  def addColumn(tableName: String, column: HColumnDescriptor): Unit
+  def addColumn(tableName: Bytes, column: HColumnDescriptor): Unit
+
+  def createTable(desc: HTableDescriptor): Unit
+  def createTable(desc: HTableDescriptor, split: Array[Bytes]): Unit
+  def createTable(
+      desc: HTableDescriptor,
+      startKey: Bytes, endKey: Bytes, numRegions: Int
+  ): Unit
+  def createTableAsync(desc: HTableDescriptor, split: Array[Bytes]): Unit
+
+  def deleteColumn(tableName: String, columnName: String): Unit
+  def deleteColumn(tableName: Bytes, columnName: Bytes): Unit
+
+  def deleteTable(tableName: String): Unit
+  def deleteTable(tableName: Bytes): Unit
+  def deleteTables(regex: String): Unit
+  def deleteTables(pattern: Pattern): Unit
+
+  def disableTable(tableName: String): Unit
+  def disableTable(tableName: Bytes): Unit
+  def disableTableAsync(tableName: String): Unit
+  def disableTableAsync(tableName: Bytes): Unit
+  def disableTables(regex: String): Unit
+  def disableTables(pattern: Pattern): Unit
+
+  def enableTable(tableName: String): Unit
+  def enableTable(tableName: Bytes): Unit
+  def enableTableAsync(tableName: String): Unit
+  def enableTableAsync(tableName: Bytes): Unit
+  def enableTables(regex: String): Unit
+  def enableTables(pattern: Pattern): Unit
+
+  def flush(tableName: String): Unit
+  def flush(tableName: Bytes): Unit
+
+  // Similar to listTables()
+  def getTableDescriptor(tableName: Bytes): HTableDescriptor
+  def getTableDescriptors(tableNames: JList[String]): Array[HTableDescriptor]
+
+  def getTableRegions(tableName: Bytes): JList[HRegionInfo]
+
+  def isTableAvailable(tableName: String): Boolean
+  def isTableAvailable(tableName: Bytes): Boolean
+
+  def isTableDisabled(tableName: String): Boolean
+  def isTableDisabled(tableName: Bytes): Boolean
+
+  def isTableEnabled(tableName: String): Boolean
+  def isTableEnabled(tableName: Bytes): Boolean
+
+  def listTables(): Array[HTableDescriptor]
+  def listTables(regex: String): Array[HTableDescriptor]
+  def listTables(pattern: Pattern): Array[HTableDescriptor]
+
+  def modifyColumn(tableName: String, column: HColumnDescriptor): Unit
+  def modifyColumn(tableName: Bytes, column: HColumnDescriptor): Unit
+
+  def modifyTable(tableName: String, desc: HTableDescriptor): Unit
+
+  def tableExists(tableName: String): Boolean
+  def tableExists(tableName: Bytes): Boolean
+}
+
+
+/** Implements conversion helpers (Bytes/String, Regex/Pattern, etc). */
+trait HBaseAdminConversionHelpers extends HBaseAdminInterface {
+  override def addColumn(tableName: String, column: HColumnDescriptor): Unit = {
+    addColumn(toBytes(tableName), column)
+  }
+
+  override def close(): Unit = {
+    // Do nothing
+  }
+
+  override def createTable(desc: HTableDescriptor): Unit = {
+    createTable(desc, split = null)
+  }
+
+  override def createTableAsync(desc: HTableDescriptor, split: Array[Bytes]): Unit = {
+    createTable(desc, split)
+  }
+
+  override def deleteColumn(tableName: String, columnName: String): Unit = {
+    deleteColumn(toBytes(tableName), toBytes(columnName))
+  }
+
+  override def deleteTable(tableName: String): Unit = {
+    deleteTable(toBytes(tableName))
+  }
+
+  override def deleteTables(regex: String): Unit = {
+    deleteTables(Pattern.compile(regex))
+  }
+  override def deleteTables(pattern: Pattern): Unit = {
+    for (desc <- listTables()) {
+      if (pattern.matcher(desc.getNameAsString).matches) {
+        deleteTable(desc.getName)
+      }
+    }
+  }
+
+  override def disableTable(tableName: String): Unit = {
+    disableTable(toBytes(tableName))
+  }
+  override def disableTableAsync(tableName: String): Unit = {
+    disableTableAsync(toBytes(tableName))
+  }
+  override def disableTableAsync(tableName: Bytes): Unit = {
+    disableTable(tableName)
+  }
+  override def disableTables(regex: String): Unit = {
+    disableTables(Pattern.compile(regex))
+  }
+  override def disableTables(pattern: Pattern): Unit = {
+    for (desc <- listTables()) {
+      if (pattern.matcher(desc.getNameAsString).matches) {
+        disableTable(desc.getName)
+      }
+    }
+  }
+
+  override def enableTable(tableName: String): Unit = {
+    enableTable(toBytes(tableName))
+  }
+  override def enableTableAsync(tableName: String): Unit = {
+    enableTableAsync(toBytes(tableName))
+  }
+  override def enableTableAsync(tableName: Bytes): Unit = {
+    enableTable(tableName)
+  }
+  override def enableTables(regex: String): Unit = {
+    enableTables(Pattern.compile(regex))
+  }
+  override def enableTables(pattern: Pattern): Unit = {
+    for (desc <- listTables()) {
+      if (pattern.matcher(desc.getNameAsString).matches) {
+        enableTable(desc.getName)
+      }
+    }
+  }
+
+  override def flush(tableName: String): Unit = {
+    flush(toBytes(tableName))
+  }
+
+  override def getTableDescriptor(tableName: Bytes): HTableDescriptor = {
+    for (desc <- listTables()) {
+      if (Arrays.equals(desc.getName, tableName)) {
+        return desc
+      }
+    }
+    throw new TableNotFoundException(Bytes.toStringBinary(tableName))
+  }
+  override def getTableDescriptors(tableNames: JList[String]): Array[HTableDescriptor] = {
+    val descs = mutable.Buffer[HTableDescriptor]()
+    val names = Set() ++ tableNames.asScala
+    for (desc <- listTables()) {
+      if (names.contains(desc.getNameAsString)) {
+        descs += desc
+      }
+    }
+    return descs.toArray
+  }
+
+  override def isTableAvailable(tableName: String): Boolean = {
+    return isTableAvailable(toBytes(tableName))
+  }
+
+  override def isTableDisabled(tableName: String): Boolean = {
+    return isTableDisabled(toBytes(tableName))
+  }
+  override def isTableDisabled(tableName: Bytes): Boolean = {
+    return !isTableEnabled(tableName)
+  }
+
+  override def isTableEnabled(tableName: String): Boolean = {
+    return isTableEnabled(toBytes(tableName))
+  }
+
+  override def listTables(regex: String): Array[HTableDescriptor] = {
+    return listTables(Pattern.compile(regex))
+  }
+  override def listTables(pattern: Pattern): Array[HTableDescriptor] = {
+    val descs = mutable.Buffer[HTableDescriptor]()
+    for (desc <- listTables()) {
+      if (pattern.matcher(desc.getNameAsString).matches) {
+        descs += desc
+      }
+    }
+    return descs.toArray
+  }
+
+  override def modifyColumn(tableName: String, column: HColumnDescriptor): Unit = {
+    modifyColumn(toBytes(tableName), column)
+  }
+
+  override def tableExists(tableName: String): Boolean = {
+    return tableExists(toBytes(tableName))
+  }
+}

--- a/src/main/scala/org/kiji/testing/fakehtable/JNavigableMapIterator.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/JNavigableMapIterator.scala
@@ -1,0 +1,65 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import java.util.{NavigableMap => JNavigableMap}
+
+/**
+ * Wraps a Java iterator on a TreeMap into a Scala iterator.
+ *
+ * JavaConverters.mapAsScalaMap does not work on NavigableMap, as it uses a HashMap internally,
+ * and this breaks the ordering while iterating on the map.
+ */
+class JNavigableMapIterator[A, B] (
+    val underlying: JNavigableMap[A, B]
+) extends Iterator[(A, B)] {
+  private val it = underlying.entrySet.iterator
+
+  override def hasNext: Boolean = {
+    return it.hasNext
+  }
+
+  override def next(): (A, B) = {
+    val entry = it.next
+    return (entry.getKey, entry.getValue)
+  }
+
+  override def hasDefiniteSize: Boolean = {
+    return true
+  }
+}
+
+/** Implicitly created wrapper to add JNavigableMap.asScalaIterator(). */
+class JNavigableMapWithAsScalaIterator[A, B](
+    val underlying: JNavigableMap[A, B]
+) {
+  def asScalaIterator(): Iterator[(A, B)] = {
+    return new JNavigableMapIterator(underlying)
+  }
+}
+
+object JNavigableMapWithAsScalaIterator {
+  /** Adds JNavigableMap.asScalaIterator(). */
+  implicit def javaNavigableMapAsScalaIterator[A, B](
+      jmap: JNavigableMap[A, B]
+  ): JNavigableMapWithAsScalaIterator[A, B] = {
+    return new JNavigableMapWithAsScalaIterator(underlying = jmap)
+  }
+}

--- a/src/main/scala/org/kiji/testing/fakehtable/Proxy.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/Proxy.scala
@@ -1,0 +1,50 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import org.easymock.internal.ClassInstantiatorFactory
+
+import net.sf.cglib.proxy.Callback
+import net.sf.cglib.proxy.Enhancer
+import net.sf.cglib.proxy.Factory
+import net.sf.cglib.proxy.MethodInterceptor
+
+/** Equivalent of java.lang.reflect.Proxy that allows proxying concrete classes. */
+object Proxy {
+  /**
+   * Creates a proxy to a given concrete class.
+   *
+   * @param klass Concrete class to proxy.
+   * @param handler Handler processing the method calls.
+   * @return a new proxy for the specified class.
+   */
+  def create[T](klass: Class[_], handler: MethodInterceptor): T = {
+    // Don't ask me how this work...
+    val enhancer = new Enhancer()
+    enhancer.setSuperclass(klass)
+    enhancer.setInterceptDuringConstruction(true)
+    enhancer.setCallbackType(handler.getClass)
+    val proxyClass: Class[_] = enhancer.createClass()
+    val proxy = ClassInstantiatorFactory.getInstantiator().newInstance(proxyClass)
+        .asInstanceOf[Factory]
+    proxy.setCallbacks(Array[Callback](handler))
+    return proxy.asInstanceOf[T]
+  }
+}

--- a/src/main/scala/org/kiji/testing/fakehtable/TimestampComparator.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/TimestampComparator.scala
@@ -1,0 +1,29 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import java.util.Comparator
+
+/** Order timestamps from the most recent ones to the oldest ones. */
+object TimestampComparator extends Comparator[Long] {
+  override def compare(long1: Long, long2: Long): Int = {
+    return long2.compareTo(long1)
+  }
+}

--- a/src/test/scala/org/kiji/testing/fakehtable/TestFakeHTable.scala
+++ b/src/test/scala/org/kiji/testing/fakehtable/TestFakeHTable.scala
@@ -1,0 +1,114 @@
+/**
+ * (c) Copyright 2012 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.testing.fakehtable
+
+import scala.collection.JavaConverters._
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.Get
+import org.apache.hadoop.hbase.client.Delete
+
+@RunWith(classOf[JUnitRunner])
+class TestFakeHTable extends FunSuite {
+
+  test("FakeHTable.get(unknownRow).isEmpty") {
+    val table = new FakeHTable(name = "table", conf = null, desc = null)
+    expect(true)(table.get(new Get("key".getBytes)).isEmpty)
+  }
+
+  test("FakeHTable.scan(emptyTable)") {
+    val table = new FakeHTable(name = "table", conf = null, desc = null)
+    expect(null)(table.getScanner("family".getBytes).next)
+  }
+
+  test("FakeHTable.delete(unknownRow)") {
+    val table = new FakeHTable(name = "table", conf = null, desc = null)
+    table.delete(new Delete("key".getBytes))
+  }
+
+  test("FakeHTable.put(row), FakeHTable.get(row)") {
+    val table = new FakeHTable(name = "table", conf = null, desc = null)
+    table.put(new Put("key".getBytes)
+        .add("family".getBytes, "qualifier".getBytes, 12345L, "value".getBytes))
+
+    val result = table.get(new Get("key".getBytes))
+    expect(false)(result.isEmpty)
+    expect("key")(new String(result.getRow))
+    expect("value")(new String(result.value))
+
+    expect(1)(result.getMap.size)
+    expect(1)(result.getMap.get("family".getBytes).size)
+    expect(1)(result.getMap.get("family".getBytes).get("qualifier".getBytes).size)
+    expect("value")(
+        new String(result.getMap.get("family".getBytes).get("qualifier".getBytes).get(12345L)))
+  }
+
+  test("FakeHTable.put(row), FakeHTable.scan(family)") {
+    val table = new FakeHTable(name = "table", conf = null, desc = null)
+    table.put(new Put("key".getBytes)
+        .add("family".getBytes, "qualifier".getBytes, 12345L, "value".getBytes))
+
+    val scanner = table.getScanner("family".getBytes)
+    val it = scanner.iterator
+    expect(true)(it.hasNext)
+    val result = it.next
+    expect(false)(result.isEmpty)
+    expect("key")(new String(result.getRow))
+    expect("value")(new String(result.value))
+
+    expect(1)(result.getMap.size)
+    expect(1)(result.getMap.get("family".getBytes).size)
+    expect(1)(result.getMap.get("family".getBytes).get("qualifier".getBytes).size)
+    expect("value")(
+        new String(result.getMap.get("family".getBytes).get("qualifier".getBytes).get(12345L)))
+
+    expect(false)(it.hasNext)
+ }
+
+ test("FakeHTable.put(row), FakeHTable.delete(row)") {
+    val table = new FakeHTable(name = "table", conf = null, desc = null)
+    table.put(new Put("key".getBytes)
+        .add("family".getBytes, "qualifier".getBytes, 12345L, "value".getBytes))
+
+    table.delete(new Delete("key".getBytes))
+    expect(true)(table.get(new Get("key".getBytes)).isEmpty)
+  }
+
+ test("FakeHTable.incrementeColumnValue") {
+   val table = new FakeHTable(name = "table", conf = null, desc = null)
+   expect(1)(table.incrementColumnValue(
+       row = "row".getBytes,
+       family = "family".getBytes,
+       qualifier = "qualifier".getBytes,
+       amount = 1))
+   expect(2)(table.incrementColumnValue(
+       row = "row".getBytes,
+       family = "family".getBytes,
+       qualifier = "qualifier".getBytes,
+       amount = 1))
+   expect(3)(table.incrementColumnValue(
+       row = "row".getBytes,
+       family = "family".getBytes,
+       qualifier = "qualifier".getBytes,
+       amount = 1))
+ }
+}


### PR DESCRIPTION
- FakeHBase instance that include FakeHTable and FakeHBaseAdmin.
  - FakeHTable supports basic operations.
  - Tool to create proxies for concrete classes (borrowed from EasyMock).
  - Work-around JavaConverters for NavigableMap.
