### PR TITLE
FakeHTable uses KijiSchema interface for HTable factories.

### DIFF
--- a/src/main/java/org/kiji/schema/impl/HTableInterfaceFactory.java
+++ b/src/main/java/org/kiji/schema/impl/HTableInterfaceFactory.java
@@ -17,14 +17,20 @@
  * limitations under the License.
  */
 
-package org.kiji.testing.fakehtable;
+package org.kiji.schema.impl;
 
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HTableInterface;
 
-/** Factory for HTableInterface. */
+/**
+ * Factory for HTableInterface.
+ *
+ * This interface is cloned from KijiSchema as a temporary workaround, to allow FakeHBase
+ * to implement it without depending on KijiSchema, and so that KijiSchema may further depend
+ * on FakeHBase.
+ */
 public interface HTableInterfaceFactory {
   /**
   * Creates a new HTableInterface instance.

--- a/src/main/scala/org/kiji/testing/fakehtable/FakeHBase.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/FakeHBase.scala
@@ -54,7 +54,7 @@ class FakeHBase {
 
   /** Factory for HTableInterface instances. */
   object InterfaceFactory
-      extends org.kiji.testing.fakehtable.HTableInterfaceFactory
+      extends org.kiji.schema.impl.HTableInterfaceFactory
       with org.apache.hadoop.hbase.client.HTableInterfaceFactory {
 
     override def create(conf: Configuration, tableName: String): HTableInterface = {


### PR DESCRIPTION
This is a temporary kludge to prevent a circular dependency between KijiSchema and FakeHTable.
