### PR TITLE
Compiled with Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,16 @@
+name := "fake-hbase"
+
+organization := "org.kiji.testing"
+
+version := "0.0.5"
+
+scalaVersion := "2.10.1"
+
+libraryDependencies ++= Seq(
+  "org.apache.hadoop" % "hadoop-common" % "2.0.0-cdh4.0.1",
+  "org.apache.hbase" % "hbase" % "0.94.3",
+  "junit" % "junit" % "4.7",
+  "cglib" % "cglib-nodep" % "2.2.2",
+  "org.easymock" % "easymock" % "3.1",
+  "org.scalatest" % "scalatest_2.10" % "2.0.M5b" % "test"
+)

--- a/src/main/scala/org/kiji/testing/fakehtable/FakeHTable.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/FakeHTable.scala
@@ -129,13 +129,13 @@ class FakeHTable(
     return !this.get(get).isEmpty()
   }
 
-  override def batch(actions: JList[Row], results: Array[Object]): Unit = {
+  override def batch(actions: java.util.List[_ <: org.apache.hadoop.hbase.client.Row], results: Array[Object]): Unit = {
     require(results.size == actions.size)
     val array = batch(actions)
     System.arraycopy(array, 0, results, 0, results.length)
   }
 
-  override def batch(actions: JList[Row]): Array[Object] = {
+  override def batch(actions: java.util.List[_ <: org.apache.hadoop.hbase.client.Row]): Array[Object] = {
     val results = Buffer[Object]()
     actions.asScala.foreach { action =>
       action match {
@@ -838,6 +838,8 @@ class FakeHTable(
     }
   }
 
+def append(x$1: org.apache.hadoop.hbase.client.Append): org.apache.hadoop.hbase.client.Result = ???
+def mutateRow(x$1: org.apache.hadoop.hbase.client.RowMutations): Unit = ???
   // -----------------------------------------------------------------------------------------------
 
 }

--- a/src/main/scala/org/kiji/testing/fakehtable/ProcessRow.scala
+++ b/src/main/scala/org/kiji/testing/fakehtable/ProcessRow.scala
@@ -154,6 +154,11 @@ object ProcessRow {
                 TimestampLoop.break
               }
             }
+            case Filter.ReturnCode.INCLUDE_AND_NEXT_COL => {
+              kvs.add(filter.transform(kv))
+              nversions += 1
+              TimestampLoop.break
+            }
             case Filter.ReturnCode.SKIP => // Skip this key/value pair.
             case Filter.ReturnCode.NEXT_COL => TimestampLoop.break
             case Filter.ReturnCode.NEXT_ROW => FamilyLoop.break


### PR DESCRIPTION
Hi, we need to use Scala 2.10 on our project and depend on fake-hbase.

This pull request contains a small number of changes:
- a build.sbt file in order to avoid messing up with the pom infrastructure
- a new case for the `Filter.ReturnCode.INCLUDE_AND_NEXT_COL` code which I hope is correct
- 2 empty implementations

It was a bit hard for me to understand exactly which combinations of hbase and hadoop-common I was supposed to rely on, so please fix those dependencies if necessary.

Going forward, it would be really nice if you could provide a cross-scala build of fake-hbase or consider a Java rewriting because the Scala incompatibility makes it unusable for us.

Thank you very much.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kijiproject/fake-hbase/15)

<!-- Reviewable:end -->
